### PR TITLE
Add Materia jetton metadata

### DIFF
--- a/jettons/materia.yaml
+++ b/jettons/materia.yaml
@@ -1,0 +1,10 @@
+address: EQCBE5gGUQ_SzQnjYp8QHjH20ls4hT02_7g6u2D9Zs9enhlV
+name: "Materia"
+symbol: "MAT"
+decimals: 0
+description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
+image: "https://bafybeih2wdahfohmvgchcald22kslgfmb27vjp6k7tf4od76pto7egbnqi.ipfs.w3s.link/materia.svg"
+websites:
+  - "https://otherworlds.ru"
+social:
+  - "https://t.me/OtherWorldsTON"

--- a/jettons/materia.yaml
+++ b/jettons/materia.yaml
@@ -3,7 +3,7 @@ name: "Materia"
 symbol: "MAT"
 decimals: 0
 description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
-image: "https://bafybeih2wdahfohmvgchcald22kslgfmb27vjp6k7tf4od76pto7egbnqi.ipfs.w3s.link/materia.svg"
+image: "https://app.other-worlds.io/images/svg/common/materia.svg"
 websites:
   - "https://other-worlds.io"
 social:

--- a/jettons/materia.yaml
+++ b/jettons/materia.yaml
@@ -5,6 +5,6 @@ decimals: 0
 description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
 image: "https://bafybeih2wdahfohmvgchcald22kslgfmb27vjp6k7tf4od76pto7egbnqi.ipfs.w3s.link/materia.svg"
 websites:
-  - "https://otherworlds.ru"
+  - "https://other-worlds.io"
 social:
   - "https://t.me/OtherWorldsTON"

--- a/jettons/materia.yaml
+++ b/jettons/materia.yaml
@@ -8,3 +8,4 @@ websites:
   - "https://other-worlds.io"
 social:
   - "https://t.me/OtherWorldsTON"
+  - "https://x.com/otherworlds_ton"


### PR DESCRIPTION
Adding metadata for the "Materia" utility token of the 'Other Worlds' Metaverse.
Used for in-game purchases, upgrades and NFTs.

address: EQCE5gGUQ_SzQnjYp8QHJH20Lsh4T02_7gGu2D9Zs9enhLV
name: "Materia"
symbol: "MAT"
decimals: 0
description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
image:"https://app.other-worlds.io/images/svg/common/materia.svg"
websites:
  - "https://other-worlds.io"
social:
  - "https://t.me/OtherWorldsTON"